### PR TITLE
Permit invocation without configuration file, for promoting ad hoc operations

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
   In this mode, the Grafana URL can optionally be defined using the
   environment variable `GRAFANA_URL`.
 * Fix exit codes in failure situations.
+* Fix exception handling and propagation in failure situations.
 
 ## 0.2.0 (2022-02-05)
 * Migrated from grafana_api to grafana_client

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 * Permit invocation without configuration file for ad hoc operations.
   In this mode, the Grafana URL can optionally be defined using the
   environment variable `GRAFANA_URL`.
+* Fix exit codes in failure situations.
 
 ## 0.2.0 (2022-02-05)
 * Migrated from grafana_api to grafana_client

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,11 @@
 
 # History
 
+## Unreleased
+* Permit invocation without configuration file for ad hoc operations.
+  In this mode, the Grafana URL can optionally be defined using the
+  environment variable `GRAFANA_URL`.
+
 ## 0.2.0 (2022-02-05)
 * Migrated from grafana_api to grafana_client
   

--- a/README.md
+++ b/README.md
@@ -21,10 +21,63 @@ Currently, there is no up-to-date version on PyPI, so we recommend to
 install directly from the repository.
 
 
-## Configuration
+## Ad Hoc Usage
 
-The configuration is stored in a YAML file. In order to connect to Grafana, you
-will need an authentication token for Grafana.
+You can use `grafana-import` in ad hoc mode without a configuration file.
+
+### Getting started
+
+In order to do some orientation flights, start a Grafana instance using Podman
+or Docker.
+```shell
+docker run --rm -it --name=grafana --publish=3000:3000 \
+  --env='GF_SECURITY_ADMIN_PASSWORD=admin' grafana/grafana:latest
+```
+
+Define Grafana endpoint.
+```shell
+export GRAFANA_URL=http://admin:admin@localhost:3000
+```
+
+### Import
+Import a dashboard from a JSON file into the `Applications` folder in Grafana.
+```shell
+grafana-import import -i grafana-dashboard.json -f Applications -o
+```
+Please note the import action preserves the version history.
+
+### Export
+Export the dashboard titled `my-first-dashboard` to the default export directory.
+```bash
+grafana-import export -d "my-first-dashboard" --pretty
+```
+
+### Delete
+Delete the dashboard titled `my-first-dashboard` from folder `Applications`.
+```bash
+grafana-import remove -f Applications -d "my-first-dashboard"
+```
+
+
+## Usage with Configuration File
+
+You can also use `grafana-import` with a configuration file. In this way, you
+can manage and use different Grafana connection profiles, and also use presets
+for application-wide configuration settings.
+
+The configuration is stored in a YAML file. In order to use it optimally,
+build a directory structure like this:
+```
+grafana-import/
+- conf/grafana-import.yml
+  Path to your main configuration file.
+- exports/
+  Path where exported dashboards will be stored.
+- imports/
+  Path where dashboards are imported from.
+```
+
+Then, enter into your directory, and type in your commands.
 
 The configuration file uses two sections, `general`, and `grafana`.
 
@@ -71,19 +124,22 @@ server URL.
 </details>
 
 
-## Usage
+## Authentication
 
-build a directory structure:
-- grafana-import/
-	- conf/grafana-import.yml
-	where your main configuration file is
-	- exports/
-	where your exported dashboards will be stored.
-	- imports/
-	where your dashboards to import are stored.
+In order to connect to Grafana, you can use either vanilla credentials
+(username/password), or an authentication token. Because `grafana-import`
+uses `grafana-client`, the same features for defining authentication
+settings can be used. See also [grafana-client authentication variants].
 
-Then, enter into your directory, and type in your commands.
-Please note the import action preserves the version history.
+Vanilla credentials can be embedded into the Grafana URL, to be supplied
+using the `--grafana_url` command line argument, or the `GRAFANA_URL`
+environment variable. For specifying a Grafana authentication token without
+using a configuration file, use the `GRAFANA_TOKEN` environment variable.
+
+[grafana-client authentication variants]: https://github.com/panodata/grafana-client/#authentication
+
+
+## Help
 
 `grafana-import --help`
 ```shell
@@ -117,6 +173,8 @@ optional arguments:
                         path to config files.
   -d DASHBOARD_NAME, --dashboard_name DASHBOARD_NAME
                         name of dashboard to export.
+  -u GRAFANA_URL, --grafana_url GRAFANA_URL
+                        Grafana URL to connect to.
   -g GRAFANA_LABEL, --grafana_label GRAFANA_LABEL
                         label in the config file that represents the grafana to
                         connect to.
@@ -131,27 +189,6 @@ optional arguments:
   -v, --verbose         verbose mode; display log message to stdout.
   -V, --version         display program version and exit..
 
-```
-
-
-## Examples
-
-### Import
-Import a dashboard from a JSON file to the folder `Applications` in Grafana.
-```shell
-grafana-import  -i my-first-dashboard_202104011548.json -f Applications -o
-```
-
-### Export
-Export the dashboard `my-first-dashboard` to the default export directory.
-```bash
-grafana-import -d "my-first-dashboard" -p export
-```
-
-### Delete
-Delete the dashboard `my-first-dashboard` from folder `Applications`.
-```bash
-grafana-import -f Applications -d "my-first-dashboard" remove
 ```
 
 

--- a/grafana_import/cli.py
+++ b/grafana_import/cli.py
@@ -262,10 +262,10 @@ def main():
          sys.exit(0)
       except Grafana.GrafanaDashboardNotFoundError as exp:
          print(f"KO: Dashboard not found in folder '{exp.folder}': {exp.dashboard}")
-         sys.exit(0)
+         sys.exit(1)
       except Grafana.GrafanaFolderNotFoundError as exp:
          print(f"KO: Folder not found: {exp.folder}")
-         sys.exit(0)
+         sys.exit(1)
       except GrafanaApi.GrafanaBadInputError as exp:
          print(f"KO: Removing dashboard failed: {dashboard_name}. Reason: {exp}")
          sys.exit(1)

--- a/grafana_import/cli.py
+++ b/grafana_import/cli.py
@@ -104,6 +104,10 @@ def main():
    parser.add_argument('-d', '--dashboard_name'
 			, help='name of dashboard to export.')
 
+   parser.add_argument('-u', '--grafana_url'
+                       , help='Grafana URL to connect to.'
+                       , required=False)
+
    parser.add_argument('-g', '--grafana_label'
 			, help='label in the config file that represents the grafana to connect to.'
          , default='default')
@@ -148,14 +152,15 @@ def main():
    if args.base_path is not None:
       base_path = inArgs.base_path
 
-   config_file = os.path.join(base_path, CONFIG_NAME)
-   if args.config_file is not None:
+   if args.config_file is None:
+      config = {"general": {"debug": False}}
+   else:
+      config_file = os.path.join(base_path, CONFIG_NAME)
       if not re.search(r'^(\.|\/)?/', config_file):
          config_file = os.path.join(base_path,args.config_file)
       else:
          config_file = args.config_file
-
-   config = load_yaml_config(config_file)
+      config = load_yaml_config(config_file)
 
    if args.verbose is None:
       if 'debug' in config['general']:
@@ -192,7 +197,7 @@ def main():
    if 'export_suffix' not in config['general'] or config['general']['export_suffix'] is None:
       config['general']['export_suffix'] = "_%Y%m%d%H%M%S"
 
-   params = grafana_settings(config=config, label=args.grafana_label)
+   params = grafana_settings(url=args.grafana_url, config=config, label=args.grafana_label)
    params.update({
          'overwrite': args.overwrite,
          'allow_new': args.allow_new,

--- a/grafana_import/grafana.py
+++ b/grafana_import/grafana.py
@@ -321,15 +321,19 @@ class Grafana(object):
                new_dash['dashboard']['uid'] = None
                new_dash['dashboard']['id'] = None
             else:
-               raise GrafanaApi.GrafanaBadInputError("dashboard already exists in an another folder and allow_new is False.")
+               raise GrafanaClient.GrafanaBadInputError(
+                  "Dashboard with the same title already exists in another folder. "
+                  "Use `allow_new` to permit creation in a different folder.")
          #** case d) send a copy to existing dash : update existing
          elif new_dash['folderId'] == old_dash['folderId']:
-            if new_dash['dashboard']['uid'] != old_dash['uid']:
+            if 'uid' not in new_dash['dashboard'] or new_dash['dashboard']['uid'] != old_dash['uid']:
                if self.overwrite:
                   new_dash['dashboard']['uid'] = old_dash['uid']
                   new_dash['dashboard']['id'] = old_dash['id']
                else:
-                  raise GrafanaApi.GrafanaBadInputError("dashboard already exists in this folder with an another id and overwrite is False.")
+                  raise GrafanaClient.GrafanaBadInputError(
+                     "Dashboard with the same title already exists in this folder with another uid. "
+                     "Use `overwrite` to permit overwriting it.")
       else:
          #force the creation of a new dashboard
          new_dash['dashboard']['uid'] = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,15 @@ from tests.util import mkdashboard, open_write_noop
 CONFIG_FILE = "grafana_import/conf/grafana-import.yml"
 
 
-def test_import_dashboard_success(mocked_grafana, mocked_responses, tmp_path, capsys):
+def get_settings_arg(use_settings: bool = True):
+    if use_settings:
+        return f"--config_file {CONFIG_FILE}"
+    else:
+        return "--grafana_url http://localhost:3000"
+
+
+@pytest.mark.parametrize("use_settings", [True, False], ids=["config-yes", "config-no"])
+def test_import_dashboard_success(mocked_grafana, mocked_responses, tmp_path, capsys, use_settings):
     """
     Verify "import dashboard" works.
     """
@@ -28,7 +36,7 @@ def test_import_dashboard_success(mocked_grafana, mocked_responses, tmp_path, ca
     dashboard_file = Path(tmp_path / "dashboard.json")
     dashboard_file.write_text(json.dumps(dashboard, indent=2))
 
-    sys.argv = shlex.split(f"grafana-import import --config_file {CONFIG_FILE} --dashboard_file {dashboard_file}")
+    sys.argv = shlex.split(f"grafana-import import {get_settings_arg(use_settings)} --dashboard_file {dashboard_file}")
 
     with pytest.raises(SystemExit) as ex:
         main()
@@ -38,7 +46,8 @@ def test_import_dashboard_success(mocked_grafana, mocked_responses, tmp_path, ca
     assert "OK: Dashboard 'Dashboard One' imported into folder 'General'" in out
 
 
-def test_export_dashboard_success(mocked_grafana, mocked_responses, capsys):
+@pytest.mark.parametrize("use_settings", [True, False], ids=["config-yes", "config-no"])
+def test_export_dashboard_success(mocked_grafana, mocked_responses, capsys, use_settings):
     """
     Verify "export dashboard" works.
     """
@@ -50,7 +59,7 @@ def test_export_dashboard_success(mocked_grafana, mocked_responses, capsys):
         content_type="application/json",
     )
 
-    sys.argv = shlex.split(f"grafana-import export --config_file {CONFIG_FILE} --dashboard_name foobar")
+    sys.argv = shlex.split(f"grafana-import export {get_settings_arg(use_settings)} --dashboard_name foobar")
 
     with pytest.raises(SystemExit) as ex:
         m = mock.patch("builtins.open", open_write_noop)
@@ -63,7 +72,8 @@ def test_export_dashboard_success(mocked_grafana, mocked_responses, capsys):
     assert re.match(r"OK: Dashboard 'foobar' exported to: ./foobar_\d+.json", out)
 
 
-def test_export_dashboard_notfound(mocked_grafana, mocked_responses, capsys):
+@pytest.mark.parametrize("use_settings", [True, False], ids=["config-yes", "config-no"])
+def test_export_dashboard_notfound(mocked_grafana, mocked_responses, capsys, use_settings):
     """
     Verify "export dashboard" fails appropriately when addressed dashboard does not exist.
     """
@@ -75,7 +85,7 @@ def test_export_dashboard_notfound(mocked_grafana, mocked_responses, capsys):
         content_type="application/json",
     )
 
-    sys.argv = shlex.split(f"grafana-import export --config_file {CONFIG_FILE} --dashboard_name foobar")
+    sys.argv = shlex.split(f"grafana-import export {get_settings_arg(use_settings)} --dashboard_name foobar")
     with pytest.raises(SystemExit) as ex:
         main()
     assert ex.match("1")
@@ -84,7 +94,8 @@ def test_export_dashboard_notfound(mocked_grafana, mocked_responses, capsys):
     assert "Dashboard name not found: foobar" in out
 
 
-def test_remove_dashboard_success(mocked_grafana, mocked_responses, settings, capsys):
+@pytest.mark.parametrize("use_settings", [True, False], ids=["config-yes", "config-no"])
+def test_remove_dashboard_success(mocked_grafana, mocked_responses, capsys, use_settings):
     """
     Verify "remove dashboard" works.
     """
@@ -95,11 +106,11 @@ def test_remove_dashboard_success(mocked_grafana, mocked_responses, settings, ca
         content_type="application/json",
     )
 
-    sys.argv = shlex.split(f"grafana-import remove --config_file {CONFIG_FILE} --dashboard_name foobar")
+    sys.argv = shlex.split(f"grafana-import remove {get_settings_arg(use_settings)} --dashboard_name foobar")
 
     with pytest.raises(SystemExit) as ex:
         main()
     assert ex.match("0")
 
     out, err = capsys.readouterr()
-    assert "OK: Dashboard removed: foobar" in  out
+    assert "OK: Dashboard removed: foobar" in out


### PR DESCRIPTION
## About
The idea of this patch is to make it possible to invoke `grafana-import` without needing to use a configuration file, in order to promote ad hoc use. We hope it will be received well.

## Usage
Instead of defining Grafana connectivity settings within the configuration file, the program now also supports defining it through the command line argument `--grafana_url`, and the environment variable `GRAFANA_URL`, in the same way [like `grafana-client` is doing it](https://github.com/panodata/grafana-client/#authentication).

## Details
In this spirit, this feature expands into quite the opposite direction what the program was originally conceived for, using a configuration file which can store **multiple Grafana connection profiles**. We think the program can well be used for both use cases, so this patch relaxes the must-have constraint about having a configuration file.

## Trivia
This is a stacked PR, based on GH-8. It can be reviewed independently, but please do not merge prematurely.

## References
- GH-7