### PR TITLE
Feature: Dashboard Builders

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,8 @@
   environment variable `GRAFANA_URL`.
 * Fix exit codes in failure situations.
 * Fix exception handling and propagation in failure situations.
+* Add feature to support dashboard builders, in the spirit of
+  dashboard-as-code.
 
 ## 0.2.0 (2022-02-05)
 * Migrated from grafana_api to grafana_client

--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@ _Export and import Grafana dashboards using the [Grafana HTTP API] and
 
 ## Features
 
-- Export Grafana dashboards into JSON format.
-- Import dashboards in JSON format into Grafana.
+- Export dashboards into JSON format.
+- Import dashboards into Grafana, both in native JSON format, or
+  emitted by dashboard builders, supporting dashboard-as-code workflows.
+  - The import action preserves the version history of dashboards.
+  - Supported builders are [grafana-dashboard], [grafanalib], and
+    any other program emitting valid Grafana Dashboard JSON on STDOUT.
 - Remove dashboards.
 
 
@@ -18,7 +22,9 @@ pip install --upgrade 'git+https://github.com/peekjef72/grafana-import-tool.git'
 ```
 
 Currently, there is no up-to-date version on PyPI, so we recommend to
-install directly from the repository.
+install directly from the repository. The command outlined above describes
+a full installation of `grafana-import`, including support for dashboard
+builders, aka. dashboard-as-code.
 
 
 ## Ad Hoc Usage
@@ -34,22 +40,36 @@ docker run --rm -it --name=grafana --publish=3000:3000 \
   --env='GF_SECURITY_ADMIN_PASSWORD=admin' grafana/grafana:latest
 ```
 
+If you don't have any Grafana dashboard representations at hand, you can
+acquire some from the `examples` directory within the `grafana-import`
+repository, like this.
+```shell
+wget https://github.com/grafana-toolbox/grafana-snippets/raw/main/dashboard/native-play-influxdb.json
+wget https://github.com/grafana-toolbox/grafana-snippets/raw/main/dashboard/gd-prometheus.py
+```
+
 Define Grafana endpoint.
 ```shell
 export GRAFANA_URL=http://admin:admin@localhost:3000
 ```
 
-### Import
-Import a dashboard from a JSON file into the `Applications` folder in Grafana.
+### Import from JSON
+Import a dashboard from a JSON file.
 ```shell
-grafana-import import -i grafana-dashboard.json -f Applications -o
+grafana-import import -i native-play-influxdb.json
 ```
-Please note the import action preserves the version history.
+
+### Import using a builder
+Import a dashboard emitted by a dashboard builder, overwriting it
+when a dashboard with the same name already exists in the same folder.
+```shell
+grafana-import import --overwrite -i gd-prometheus.py
+```
 
 ### Export
 Export the dashboard titled `my-first-dashboard` to the default export directory.
 ```bash
-grafana-import export -d "my-first-dashboard" --pretty
+grafana-import export --pretty -d "my-first-dashboard"
 ```
 
 ### Delete
@@ -205,3 +225,5 @@ learn how to set up a [development sandbox].
 [development sandbox]: ./docs/sandbox.md
 [Grafana HTTP API]: https://grafana.com/docs/grafana/latest/http_api/
 [grafana-client]: https://github.com/panodata/grafana-client
+[grafana-dashboard]: https://github.com/fzyzcjy/grafana_dashboard_python
+[grafanalib]: https://github.com/weaveworks/grafanalib

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,0 +1,7 @@
+# grafana-import backlog
+
+- `grafana-dashboard` offers the option to convert Grafana JSON
+  back to Python code. It should be used on the `export` subsystem,
+  to provide an alternative output format.
+  https://github.com/fzyzcjy/grafana_dashboard_python/tree/master/examples/json_to_python
+- Provide support for the Grafana `cog` builder

--- a/grafana_import/cli.py
+++ b/grafana_import/cli.py
@@ -25,7 +25,7 @@ from datetime import datetime
 import grafana_client.client as GrafanaApi
 import grafana_import.grafana as Grafana
 
-from grafana_import.util import load_yaml_config, grafana_settings
+from grafana_import.util import load_yaml_config, grafana_settings, read_dashboard_file
 
 #******************************************************************************************
 config = None
@@ -214,27 +214,20 @@ def main():
       if args.dashboard_file is None:
          print('ERROR: no file to import provided!')
          sys.exit(1)
+
+      # Compute effective input file path.
       import_path = ''
       import_file = args.dashboard_file
       if not re.search(r'^(?:(?:/)|(?:\.?\./))', import_file):
          import_path = base_path
          if 'imports_path' in config['general']:
             import_path = os.path.join(import_path, config['general']['imports_path'] )
-      import_path = os.path.join(import_path, import_file)
+      import_file = os.path.join(import_path, import_file)
 
       try:
-         input = open(import_path, 'r')
-      except OSError as e:
-         print('ERROR: File {0} error: {1}.'.format(import_path, e.strerror))
-         sys.exit(1)
-
-      data = input.read()
-      input.close()
-
-      try:
-         dash = json.loads(data)
-      except json.JSONDecodeError as e:
-         print("ERROR: reading '{0}': {1}".format(import_path, e))
+         dash = read_dashboard_file(import_file)
+      except Exception as ex:
+         print(f"ERROR: Failed to import dashboard from: {import_file}. Reason: {ex}")
          sys.exit(1)
 
       try:

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,10 @@ requires = [
 ]
 
 extras = {
+    "builder": [
+        "grafana-dashboard==0.1.1",
+        "grafanalib==0.7.1",
+    ],
     "develop": [
         "black<25",
         "mypy<1.10",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import pytest
+import requests
+
+from grafana_import.util import read_dashboard_file
+
+MINIMAL_JSON_URL = "https://github.com/grafana-toolbox/grafana-snippets/raw/main/dashboard/native-minimal.json"
+
+
+@pytest.fixture
+def minimal_json_payload() -> str:
+    return requests.get(MINIMAL_JSON_URL, timeout=5).text
+
+
+def test_read_dashboard_json(tmp_path, minimal_json_payload):
+    """
+    Verify reading a traditional Grafana dashboard in JSON format.
+    """
+    minimal_json = Path(tmp_path) / "minimal.json"
+    minimal_json.write_text(minimal_json_payload)
+
+    dashboard = read_dashboard_file(minimal_json)
+    assert dashboard["title"] == "grafana-snippets » Synthetic minimal dashboard"
+
+
+def test_read_dashboard_python(tmp_path, minimal_json_payload):
+    """
+    Verify reading a traditional Grafana dashboard in JSON format.
+    """
+    minimal_json = Path(tmp_path) / "minimal.json"
+    minimal_json.write_text(minimal_json_payload)
+
+    dashboard = read_dashboard_file(minimal_json)
+    assert dashboard["title"] == "grafana-snippets » Synthetic minimal dashboard"
+
+
+def test_read_dashboard_unknown(tmp_path):
+    """
+    A file name without a known suffix will trip the program.
+    """
+    example_foo = Path(tmp_path) / "example.foo"
+    example_foo.touch()
+
+    with pytest.raises(NotImplementedError) as ex:
+        read_dashboard_file(example_foo)
+    assert ex.match("Decoding file type not implemented, or file is not executable: example.foo")
+
+
+def test_read_dashboard_builder_file_executable(tmp_path):
+    """
+    A file name without suffix will automatically be considered a builder, and must be executable.
+    """
+    builder = Path(tmp_path) / "minimal-builder"
+    builder.write_text(f"#!/usr/bin/env sh\ncurl --location {MINIMAL_JSON_URL}")
+    builder.chmod(0o777)
+
+    dashboard = read_dashboard_file(builder)
+    assert dashboard["title"] == "grafana-snippets » Synthetic minimal dashboard"
+
+
+def test_read_dashboard_builder_unknown(tmp_path):
+    """
+    A file of "builder" nature, which is not executable, will trip the program.
+    """
+    builder = Path(tmp_path) / "unknown-builder"
+    builder.touch()
+
+    with pytest.raises(NotImplementedError) as ex:
+        read_dashboard_file(builder)
+    assert ex.match("Decoding file type not implemented, or file is not executable: unknown-builder")


### PR DESCRIPTION
## About
The idea of this patch is to make it possible to support dashboard-as-code workflows, by using dashboard builders, in this case, [grafana-dashboard] or [grafanalib], for having a start.

[grafana-dashboard]: https://github.com/fzyzcjy/grafana_dashboard_python
[grafanalib]: https://github.com/weaveworks/grafanalib

## Usage
On the `import` action, it is not much different than before. Now, beyond accepting dashboards in JSON format, the program will also accept arbitrary file paths. When applicable, they will be treated as executable programs, expected to generate valid native Grafana JSON on STDOUT.

## Synopsis
Prepare.
```shell
wget https://github.com/grafana-toolbox/grafana-snippets/raw/main/dashboard/gd-prometheus.py
export GRAFANA_URL=http://admin:admin@localhost:3000
```
Import a dashboard emitted by a dashboard builder, overwriting it when a dashboard with the same name already exists in the same folder.
```shell
grafana-import import --overwrite -i gd-prometheus.py
```

## Trivia
This is a stacked PR, based on GH-9. It can be reviewed independently, but please do not merge prematurely.

## References
- GH-7