### PR TITLE
Chore: Adjust GitHub project organization and name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ You can contribute in many ways:
 
 ### Report Bugs
 
-Report bugs at https://github.com/peekjef72/grafana-import-tool/issues.
+Report bugs at https://github.com/grafana-toolbox/grafana-import/issues.
 
 If you are reporting a bug, please include:
 
@@ -35,7 +35,7 @@ articles, and such.
 
 ### Submit Feedback
 
-The best way to send feedback is to file an issue at https://github.com/peekjef72/grafana-import-tool/issues
+The best way to send feedback is to file an issue at https://github.com/grafana-toolbox/grafana-import/issues
 
 If you are proposing a feature:
 
@@ -49,13 +49,13 @@ If you are proposing a feature:
 Ready to contribute? Here's how to set up `grafana-import` for
 local development.
 
-1. _Fork_ the `grafana-import-tool` repo on GitHub.
+1. _Fork_ the `grafana-import` repo on GitHub.
 
- [Fork](https://github.com/peekjef72/grafana-import-tool/fork)
+ [Fork](https://github.com/grafana-toolbox/grafana-import/fork)
 
 2. Clone your fork locally:
 
-    $ git clone git@github.com:your_name_here/grafana-import-tool.git
+    $ git clone git@github.com:your_name_here/grafana-import.git
 
 3. Create a branch for local development:
 
@@ -64,7 +64,7 @@ local development.
 Now you can make your changes locally.
 
 4. When you're done making changes, check that your changes pass style and unit
-   tests, including testing other Python versions with grafana-import-tool
+   tests, including testing other Python versions with grafana-import
 
     $ grafana-import
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@ _Export and import Grafana dashboards using the [Grafana HTTP API] and
   emitted by dashboard builders, supporting dashboard-as-code workflows.
   - The import action preserves the version history of dashboards.
   - Supported builders are [grafana-dashboard], [grafanalib], and
-    any other program emitting valid Grafana Dashboard JSON on STDOUT.
+    any other executable program which emits Grafana Dashboard JSON
+    on STDOUT.
 - Remove dashboards.
 
 
 ## Installation
 
 ```shell
-pip install --upgrade 'git+https://github.com/peekjef72/grafana-import-tool.git'
+pip install --upgrade 'grafana-import[builder] git+https://github.com/grafana-toolbox/grafana-import.git'
 ```
 
 Currently, there is no up-to-date version on PyPI, so we recommend to

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -7,8 +7,8 @@ After invoking `poe check`, and observing the software tests succeed, you
 should be ready to start hacking.
 
 ```shell
-git clone https://github.com/peekjef72/grafana-import-tool
-cd grafana-import-tool
+git clone https://github.com/grafana-toolbox/grafana-import
+cd grafana-import
 python3 -m venv .venv
 source .venv/bin/activate
 pip install --editable='.[develop,test]'

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     license="Apache 2.0",
     author="Jean-Francois Pik",
     author_email="jfpik78@gmail.com",
-    url="https://github.com/peekjef72/grafana-import-tool",
+    url="https://github.com/grafana-toolbox/grafana-import",
     entry_points={
         'console_scripts': [
             'grafana-import = grafana_import.cli:main'


### PR DESCRIPTION
The project has been relocated and renamed to `grafana-toolbox/grafana-import`. This patch adjusts that, as suggested by @peekjef72 at https://github.com/grafana-toolbox/grafana-import/pull/8#pullrequestreview-2019954866. Thanks.