### PR TITLE
Feature: Watchdog with Reloading

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,8 @@
 * Fix exception handling and propagation in failure situations.
 * Add feature to support dashboard builders, in the spirit of
   dashboard-as-code.
+* Add watchdog feature, monitoring the input dashboard for changes on
+  disk, and re-uploading it, when changed.
 
 ## 0.2.0 (2022-02-05)
 * Migrated from grafana_api to grafana_client

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ _Export and import Grafana dashboards using the [Grafana HTTP API] and
   - Supported builders are [grafana-dashboard], [grafanalib], and
     any other executable program which emits Grafana Dashboard JSON
     on STDOUT.
+- Watchdog: For a maximum of authoring and editing efficiency, the
+  watchdog monitors the input dashboard for changes on disk, and
+  re-uploads it to the Grafana API, when changed.
 - Remove dashboards.
 
 
@@ -65,6 +68,12 @@ Import a dashboard emitted by a dashboard builder, overwriting it
 when a dashboard with the same name already exists in the same folder.
 ```shell
 grafana-import import --overwrite -i gd-prometheus.py
+```
+
+### Import using reloading
+Watch the input dashboard for changes on disk, and re-upload it, when changed.
+```shell
+grafana-import import --overwrite --reload -i gd-prometheus.py
 ```
 
 ### Export
@@ -205,10 +214,12 @@ optional arguments:
                         path to the dashboard file to import into Grafana.
   -o, --overwrite       if a dashboard with same name exists in folder,
                         overwrite it with this new one.
+  -r, --reload          Watch the input dashboard for changes on disk, and
+                        re-upload it, when changed.
   -p, --pretty          use JSON indentation when exporting or extraction of
                         dashboards.
   -v, --verbose         verbose mode; display log message to stdout.
-  -V, --version         display program version and exit..
+  -V, --version         display program version and exit.
 
 ```
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,7 @@
 # grafana-import backlog
 
+## Iteration +1
+- Print dashboard URL after uploading
 - `grafana-dashboard` offers the option to convert Grafana JSON
   back to Python code. It should be used on the `export` subsystem,
   to provide an alternative output format.

--- a/grafana_import/service.py
+++ b/grafana_import/service.py
@@ -1,0 +1,50 @@
+import logging
+import time
+import typing as t
+from pathlib import Path
+
+from watchdog.events import FileSystemEvent, PatternMatchingEventHandler
+from watchdog.observers import Observer
+
+logger = logging.getLogger(__name__)
+
+
+class SingleFileModifiedHandler(PatternMatchingEventHandler):
+
+    def __init__(
+        self,
+        *args,
+        action: t.Union[t.Callable, None] = None,
+        **kwargs,
+    ):
+        self.action = action
+        super().__init__(*args, **kwargs)
+
+    def on_modified(self, event: FileSystemEvent) -> None:
+        super().on_modified(event)
+        logger.info(f"File was modified: {event.src_path}")
+        try:
+            self.action and self.action()
+            logger.debug(f"File processed successfully: {event.src_path}")
+        except Exception:
+            logger.exception(f"Processing file failed: {event.src_path}")
+
+
+def watchdog_service(path: Path, action: t.Union[t.Callable, None] = None):
+    """
+    https://python-watchdog.readthedocs.io/en/stable/quickstart.html
+    """
+
+    import_file = Path(path).absolute()
+    import_path = import_file.parent
+
+    event_handler = SingleFileModifiedHandler(action=action, patterns=[import_file.name], ignore_directories=True)
+    observer = Observer()
+    observer.schedule(event_handler, str(import_path), recursive=False)
+    observer.start()
+    try:
+        while True:
+            time.sleep(1)
+    finally:
+        observer.stop()
+        observer.join()

--- a/grafana_import/util.py
+++ b/grafana_import/util.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import shlex
 import subprocess
@@ -10,6 +11,11 @@ import yaml
 
 ConfigType = t.Dict[str, t.Any]
 SettingsType = t.Dict[str, t.Union[str, int, bool]]
+
+
+def setup_logging(level=logging.INFO, verbose: bool = False):
+    log_format = "%(asctime)-15s [%(name)-26s] %(levelname)-8s: %(message)s"
+    logging.basicConfig(format=log_format, stream=sys.stderr, level=level)
 
 
 def load_yaml_config(config_file: str) -> ConfigType:

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ requires = [
     'grafana-client<5',
     'jinja2<4',
     'pyyaml<7',
+    'watchdog<5',
 ]
 
 extras = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from grafana_import.grafana import Grafana
 from grafana_import.util import grafana_settings, load_yaml_config
 from tests.util import mock_grafana_health, mock_grafana_search
 
-
 if sys.version_info < (3, 9):
     from importlib_resources import files
 else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ def get_settings_arg(use_settings: bool = True):
 
 
 @pytest.mark.parametrize("use_settings", [True, False], ids=["config-yes", "config-no"])
-def test_import_dashboard_success(mocked_grafana, mocked_responses, tmp_path, capsys, use_settings):
+def test_import_dashboard_success(mocked_grafana, mocked_responses, tmp_path, caplog, use_settings):
     """
     Verify "import dashboard" works.
     """
@@ -42,8 +42,7 @@ def test_import_dashboard_success(mocked_grafana, mocked_responses, tmp_path, ca
         main()
     assert ex.match("0")
 
-    out, err = capsys.readouterr()
-    assert "OK: Dashboard 'Dashboard One' imported into folder 'General'" in out
+    assert "Dashboard 'Dashboard One' imported into folder 'General'" in caplog.messages
 
 
 @pytest.mark.parametrize("use_settings", [True, False], ids=["config-yes", "config-no"])


### PR DESCRIPTION
## About
The idea of this patch is to make `grafana-import` support almost end-to-end dashboard-as-code authoring/editing workflows, expanding the "builder support" feature introduced by GH-10 by a "watchdog" feature.

When enabled, it watches the input dashboard for changes on disk, and, when changed, it re-uploads the dashboard to the Grafana API. It is using the [watchdog] package to do its job. Thanks, @gorakhargosh.
 
[watchdog]: https://pypi.org/project/watchdog/

## Usage
On the `import` action, the feature can be enabled using the `--reload` command line option.

## Synopsis
Prepare.
```shell
wget https://github.com/grafana-toolbox/grafana-snippets/raw/main/dashboard/gd-prometheus.py
export GRAFANA_URL=http://admin:admin@localhost:3000
```
Watch the input dashboard for changes on disk, and re-upload it, when changed.
```shell
grafana-import import --overwrite --reload -i gd-prometheus.py
```

## References
- GH-7
