### PR TITLE
fix(auth): pass GRAFANA_TOKEN env variable on Grafana initialization

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,8 @@
   JSON.
 * Add watchdog feature, monitoring the input dashboard for changes on
   disk, and re-uploading it, when changed.
+* Pass `GRAFANA_TOKEN` environment variable on Grafana initialization.
+  Thanks, @jl2397.
 
 ## 0.2.0 (2022-02-05)
 * Migrated from grafana_api to grafana_client

--- a/grafana_import/grafana.py
+++ b/grafana_import/grafana.py
@@ -1,3 +1,4 @@
+import os
 import re
 import traceback
 import typing as t
@@ -65,7 +66,9 @@ class Grafana:
 
         # Configure Grafana connectivity.
         if "url" in kwargs:
-            self.grafana_api = GrafanaApi.GrafanaApi.from_url(kwargs["url"])
+            self.grafana_api = GrafanaApi.GrafanaApi.from_url(
+                url=kwargs["url"], credential=os.environ.get("GRAFANA_TOKEN")
+            )
         else:
             config = {}
             config["protocol"] = kwargs.get("protocol", "http")


### PR DESCRIPTION
Improvement submitted by @jl2397. Thanks!

> When the Grafana class is initialized in grafana.py, there is only a check for the "url" field in the parameters. If the GRAFANA_TOKEN env variable is set, the token is never passed to the GrafanaApi client and therefore results in a GrafanaUnauthorizedError when making requests using grafana_client. This adds a credential field to the from_url call and populates it with the GRAFANA_TOKEN env variable.

This is coming from GH-19, but needed more code formatting.
