### PR TITLE
CI: Use Ubuntu 22 runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-22.04"]
-        python-version: ["3.7", "3.13"]
+        python-version: ["3.8", "3.13"]
       fail-fast: false
 
     services:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-22.04"]
-        python-version: ["3.6", "3.13"]
+        python-version: ["3.7", "3.13"]
       fail-fast: false
 
     services:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-20.04"]
+        os: ["ubuntu-22.04"]
         python-version: ["3.6", "3.13"]
       fail-fast: false
 


### PR DESCRIPTION
GH-36 got stuck because Ubuntu 20 runners are gone.